### PR TITLE
:art: Use `libhal_make_library`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(libhal-micromod VERSION 0.0.1 LANGUAGES CXX)
+project(libhal-micromod LANGUAGES CXX)
 
 set(platform_library $ENV{LIBHAL_PLATFORM_LIBRARY})
 set(platform $ENV{LIBHAL_PLATFORM})
@@ -25,17 +25,19 @@ message(NOTICE ">> 🔎 Platform library = ${platform}")
 
 if("${platform_library}" STREQUAL "")
   message(FATAL_ERROR
-    "Build environment variable LIBHAL_PLATFORM_LIBRARY is required for " "this project.")
+    "Build environment variable LIBHAL_PLATFORM_LIBRARY is required for "
+    "this project.")
 endif()
 
-find_package(libhal-${platform_library} REQUIRED CONFIG)
+libhal_make_library(
+  LIBRARY_NAME libhal-micromod
 
-add_library(libhal-micromod src/${platform}.cpp)
-target_include_directories(libhal-micromod PUBLIC include)
-target_compile_features(libhal-micromod PRIVATE cxx_std_20)
-target_compile_options(libhal-micromod PRIVATE -Wall -Wextra)
-target_link_libraries(libhal-micromod PRIVATE
+  SOURCES
+  src/${platform}.cpp
+
+  PACKAGES
+  libhal-${platform_library}
+
+  LINK_LIBRARIES
   libhal::${platform_library}
 )
-
-install(TARGETS libhal-micromod)

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,7 +25,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_micromod_conan(ConanFile):
     name = "libhal-micromod"
-    version = "0.2.1"
+    version = "0.2.2"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/libhal/libhal-micromod"
@@ -60,12 +60,12 @@ class libhal_micromod_conan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("cmake/3.27.1")
-        self.tool_requires("libhal-cmake-util/1.0.0")
+        self.tool_requires("libhal-cmake-util/1.2.0")
 
     def requirements(self):
         platform_str = str(self.options.platform)
         if platform_str == "lpc4078":
-            self.requires("libhal-lpc40/2.1.1")
+            self.requires("libhal-lpc40/2.1.3")
         elif platform_str == "stm32f103c8":
             self.requires("libhal-stm32f1/2.0.3")
         else:


### PR DESCRIPTION
- Simplifies building libhal libraries and packages
- By using the standard cmake utilities, upgrades are easily installed by bumping the libhal-cmake-util version number
- Utilizes clang-tidy